### PR TITLE
Add support for fill prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This was tested with RN 0.33 and react-native-svg 4.3.1 (depends on this library
 [react-native-svg](https://github.com/react-native-community/react-native-svg)
 
 
-Not all the svgs can be rendered, if you find problems fill an issue or a PR in 
+Not all the svgs can be rendered, if you find problems fill an issue or a PR in
 order to contemplate all the cases
 
 Install library from `npm`
@@ -13,13 +13,13 @@ Install library from `npm`
   ```bash
   npm install react-native-svg-uri --save
   ```
-  
+
 Link library react-native-svg
 
   ```bash
   react-native link react-native-svg
-  ```   
-  
+  ```
+
 ### <a name="Usage">Usage</a>
 
 Here's a simple example:
@@ -32,7 +32,7 @@ class TestSvgUri extends Component {
     return (
       <View style={styles.container}>
          <SvgUri width="200" height="200"
-                 source={{uri:'http://thenewcode.com/assets/images/thumbnails/homer-simpson.svg'}} /> 
+                 source={{uri:'http://thenewcode.com/assets/images/thumbnails/homer-simpson.svg'}} />
       </View>
     );
   }
@@ -42,10 +42,7 @@ class TestSvgUri extends Component {
 or a static file
 
 ```javascript
- 
-         <SvgUri width="200" height="200"
-                 source={require('./images/homer.svg')} /> 
-     
+<SvgUri width="200" height="200" source={require('./img/homer.svg')} />
 ```
 
 This will render:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ Link library react-native-svg
   react-native link react-native-svg
   ```
 
-### <a name="Usage">Usage</a>
+## Props
+
+| Prop | Type | Default | Note |
+|---|---|---|---|
+| `source` | `ImageSource` |  | Same kind of `source` prop that `<Image />` component has
+| `fill` | `string` |  | Overrides all fill attributes of the svg file
+
+## <a name="Usage">Usage</a>
 
 Here's a simple example:
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,15 @@ Here's a simple example:
 ```javascript
 import SvgUri from 'react-native-svg-uri';
 
-class TestSvgUri extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-         <SvgUri width="200" height="200"
-                 source={{uri:'http://thenewcode.com/assets/images/thumbnails/homer-simpson.svg'}} />
-      </View>
-    );
-  }
-}
+const TestSvgUri = () => (
+  <View style={styles.container}>
+    <SvgUri
+      width="200"
+      height="200"
+      source={{uri:'http://thenewcode.com/assets/images/thumbnails/homer-simpson.svg'}}
+    />
+  </View>
+);
 ```
 
 or a static file
@@ -49,4 +48,3 @@ This will render:
 
 
 ![Component example](./screenshoots/sample.png)
-

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Link library react-native-svg
 | Prop | Type | Default | Note |
 |---|---|---|---|
 | `source` | `ImageSource` |  | Same kind of `source` prop that `<Image />` component has
-| `fill` | `string` |  | Overrides all fill attributes of the svg file
+| `fill` | `Color` |  | Overrides all fill attributes of the svg file
 
 ## <a name="Usage">Usage</a>
 

--- a/index.js
+++ b/index.js
@@ -128,17 +128,16 @@ class SvgUri extends Component{
       let validAttributes = {};
 
       for (let i = 0; i < node.attributes.length; i++) {
-          const attribute = node.attributes[i].nodeName;
-          const attributeValue = node.attributes[i].nodeValue;
+          const {nodeName, nodeValue} = node.attributes[i];
           
-          if (attribute in transformAttributes) {
-            Object.assign(validAttributes, this.transformSVGAtt(attribute, attributeValue));
+          if (nodeName in transformAttributes) {
+            Object.assign(validAttributes, this.transformSVGAtt(nodeName, nodeValue));
           } 
-          else if (attribute in ATTS_TRANSFORMED_NAMES) {
-            validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
+          else if (nodeName in ATTS_TRANSFORMED_NAMES) {
+            validAttributes[ATTS_TRANSFORMED_NAMES[nodeName]] = nodeValue;
           } 
-          else if (attribute in enabledAttributes) {
-            validAttributes[attribute] = this.props.fill && attribute === 'fill' ? this.props.fill : attributeValue;
+          else if (nodeName in enabledAttributes) {
+            validAttributes[nodeName] = this.props.fill && nodeName === 'fill' ? this.props.fill : nodeValue;
           }
       }
 

--- a/index.js
+++ b/index.js
@@ -133,8 +133,7 @@ class SvgUri extends Component{
           const attributeValue = node.attributes[i].nodeValue;
           
           if (attribute in ATTS_TRANSFORM) {
-            const transformedAttribute = this.transformSVGAtt(attribute, attributeValue);
-            Object.assign(validAttributes, transformedAttribute);
+            Object.assign(validAttributes, this.transformSVGAtt(attribute, attributeValue));
           } 
           else if (attribute in ATTS_TRANSFORMED_NAMES) {
             validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;

--- a/index.js
+++ b/index.js
@@ -146,8 +146,8 @@ class SvgUri extends Component{
               }
           }
       }
-      
-      if (this.props.fill) {
+
+      if (this.props.fill && 'fill' in ATTS_ENABLED) {
         return Object.assign({}, componentAtts, { fill: this.props.fill });
       }
 

--- a/index.js
+++ b/index.js
@@ -124,10 +124,10 @@ class SvgUri extends Component{
         }
   }
 
-  obtainComponentAtts(node, enabledAttributes, transformAttributes) {
+  obtainComponentAtts({attributes}, enabledAttributes, transformAttributes) {
       let validAttributes = {};
 
-      node.attributes.forEach(({nodeName, nodeValue}) => {
+      attributes.forEach(({nodeName, nodeValue}) => {
           if (nodeName in transformAttributes) {
             Object.assign(validAttributes, this.transformSVGAtt(nodeName, nodeValue));
           } 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,6 @@ class SvgUri extends Component{
     this.state = {svgXmlData:null};
 
     this.createSVGElement     = this.createSVGElement.bind(this);
-    this.transformSVGAtt      = this.transformSVGAtt.bind(this);
     this.obtainComponentAtts  = this.obtainComponentAtts.bind(this);
     this.inspectNode          = this.inspectNode.bind(this);
     this.fecthSVGData         = this.fecthSVGData.bind(this);
@@ -148,7 +147,7 @@ class SvgUri extends Component{
       return validAttributes;
   }
 
-  transformSVGAtt(attName, attValue){
+  transformSVGAtt(attName, attValue) {
       if (attName == 'style'){
           let styleAtts = attValue.split(';');
           let newAtts = {};

--- a/index.js
+++ b/index.js
@@ -141,12 +141,7 @@ class SvgUri extends Component{
             validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
           } 
           else if (attribute in ATTS_ENABLED) {
-            if (this.props.fill && attribute === 'fill') {
-                validAttributes[attribute] = this.props.fill;
-            }
-            else {
-                validAttributes[attribute] = attributeValue;
-            }
+            validAttributes[attribute] = this.props.fill && attribute === 'fill' ? this.props.fill : attributeValue;
           }
       }
 

--- a/index.js
+++ b/index.js
@@ -129,14 +129,16 @@ class SvgUri extends Component{
   obtainComponentAtts(node, ATTS_ENABLED, ATTS_TRANSFORM){
       let componentAtts = {};
       for (let i = 0; i < node.attributes.length; i++) {
-          let att = node.attributes[i];
-          if (att.nodeName in ATTS_TRANSFORM) {
-            const transformedAttribute = this.transformSVGAtt(node.nodeName, att.nodeName, att.nodeValue);
+          const attribute = node.attributes[i].nodeName;
+          const attributeValue = node.attributes[i].nodeValue;
+          
+          if (attribute in ATTS_TRANSFORM) {
+            const transformedAttribute = this.transformSVGAtt(node.nodeName, attribute, attributeValue);
             componentAtts = Object.assign({}, componentAtts, transformedAttribute);
-          } else if (att.nodeName in ATTS_TRANSFORMED_NAMES) {
-            componentAtts[ATTS_TRANSFORMED_NAMES[att.nodeName]] = att.nodeValue;
-          } else if (att.nodeName in ATTS_ENABLED) {
-            componentAtts[att.nodeName] = att.nodeValue;
+          } else if (attribute in ATTS_TRANSFORMED_NAMES) {
+            componentAtts[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
+          } else if (attribute in ATTS_ENABLED) {
+            componentAtts[attribute] = attributeValue;
           }
       }
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ class SvgUri extends Component{
         }
   }
 
-  obtainComponentAtts(node, ATTS_ENABLED, ATTS_TRANSFORM){
+  obtainComponentAtts(node, ATTS_ENABLED, ATTS_TRANSFORM) {
       let componentAtts = {};
       for (let i = 0; i < node.attributes.length; i++) {
           const attribute = node.attributes[i].nodeName;

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ class SvgUri extends Component{
           
           if (attribute in ATTS_TRANSFORM) {
             const transformedAttribute = this.transformSVGAtt(attribute, attributeValue);
-            validAttributes = Object.assign({}, validAttributes, transformedAttribute);
+            Object.assign(validAttributes, transformedAttribute);
           } 
           else if (attribute in ATTS_TRANSFORMED_NAMES) {
             validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;

--- a/index.js
+++ b/index.js
@@ -131,8 +131,8 @@ class SvgUri extends Component{
       for (let i = 0; i < node.attributes.length; i++) {
           let att = node.attributes[i];
           if (att.nodeName in ATTS_TRANSFORM) {
-            att = this.transformSVGAtt(node.nodeName, att.nodeName, att.nodeValue);
-            componentAtts = Object.assign({}, componentAtts, att);
+            const transformedAttribute = this.transformSVGAtt(node.nodeName, att.nodeName, att.nodeValue);
+            componentAtts = Object.assign({}, componentAtts, transformedAttribute);
           } else if (att.nodeName in ATTS_TRANSFORMED_NAMES) {
             componentAtts[ATTS_TRANSFORMED_NAMES[att.nodeName]] = att.nodeValue;
           } else if (att.nodeName in ATTS_ENABLED) {

--- a/index.js
+++ b/index.js
@@ -127,9 +127,7 @@ class SvgUri extends Component{
   obtainComponentAtts(node, enabledAttributes, transformAttributes) {
       let validAttributes = {};
 
-      for (let i = 0; i < node.attributes.length; i++) {
-          const {nodeName, nodeValue} = node.attributes[i];
-          
+      node.attributes.forEach(({nodeName, nodeValue}) => {
           if (nodeName in transformAttributes) {
             Object.assign(validAttributes, this.transformSVGAtt(nodeName, nodeValue));
           } 
@@ -139,7 +137,7 @@ class SvgUri extends Component{
           else if (nodeName in enabledAttributes) {
             validAttributes[nodeName] = this.props.fill && nodeName === 'fill' ? this.props.fill : nodeValue;
           }
-      }
+      });
 
       return validAttributes;
   }

--- a/index.js
+++ b/index.js
@@ -146,6 +146,11 @@ class SvgUri extends Component{
               }
           }
       }
+      
+      if (this.props.fill) {
+        return Object.assign({}, componentAtts, { fill: this.props.fill });
+      }
+
       return componentAtts;
   }
 

--- a/index.js
+++ b/index.js
@@ -127,26 +127,26 @@ class SvgUri extends Component{
   }
 
   obtainComponentAtts(node, ATTS_ENABLED, ATTS_TRANSFORM) {
-      let componentAtts = {};
+      let validAttributes = {};
       for (let i = 0; i < node.attributes.length; i++) {
           const attribute = node.attributes[i].nodeName;
           const attributeValue = node.attributes[i].nodeValue;
           
           if (attribute in ATTS_TRANSFORM) {
             const transformedAttribute = this.transformSVGAtt(node.nodeName, attribute, attributeValue);
-            componentAtts = Object.assign({}, componentAtts, transformedAttribute);
+            validAttributes = Object.assign({}, validAttributes, transformedAttribute);
           } else if (attribute in ATTS_TRANSFORMED_NAMES) {
-            componentAtts[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
+            validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
           } else if (attribute in ATTS_ENABLED) {
-            componentAtts[attribute] = attributeValue;
+            validAttributes[attribute] = attributeValue;
           }
       }
 
       if (this.props.fill && 'fill' in ATTS_ENABLED) {
-        return Object.assign({}, componentAtts, { fill: this.props.fill });
+        return Object.assign({}, validAttributes, { fill: this.props.fill });
       }
 
-      return componentAtts;
+      return validAttributes;
   }
 
   transformSVGAtt(component, attName, attValue){

--- a/index.js
+++ b/index.js
@@ -219,4 +219,8 @@ class SvgUri extends Component{
 	}
 }
 
+SvgUri.propTypes = {
+  fill: PropTypes.string,
+}
+
 module.exports = SvgUri;

--- a/index.js
+++ b/index.js
@@ -125,20 +125,20 @@ class SvgUri extends Component{
         }
   }
 
-  obtainComponentAtts(node, ATTS_ENABLED, ATTS_TRANSFORM) {
+  obtainComponentAtts(node, enabledAttributes, transformAttributes) {
       let validAttributes = {};
 
       for (let i = 0; i < node.attributes.length; i++) {
           const attribute = node.attributes[i].nodeName;
           const attributeValue = node.attributes[i].nodeValue;
           
-          if (attribute in ATTS_TRANSFORM) {
+          if (attribute in transformAttributes) {
             Object.assign(validAttributes, this.transformSVGAtt(attribute, attributeValue));
           } 
           else if (attribute in ATTS_TRANSFORMED_NAMES) {
             validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
           } 
-          else if (attribute in ATTS_ENABLED) {
+          else if (attribute in enabledAttributes) {
             validAttributes[attribute] = this.props.fill && attribute === 'fill' ? this.props.fill : attributeValue;
           }
       }

--- a/index.js
+++ b/index.js
@@ -140,8 +140,6 @@ class SvgUri extends Component{
               }else{
                   if (att.nodeName in ATTS_ENABLED){ // Valida que el atributo sea mapeable
                       componentAtts[att.nodeName] = att.nodeValue;
-                  }else{
-                      ;
                   }
               }
           }

--- a/index.js
+++ b/index.js
@@ -135,9 +135,11 @@ class SvgUri extends Component{
           if (attribute in ATTS_TRANSFORM) {
             const transformedAttribute = this.transformSVGAtt(node.nodeName, attribute, attributeValue);
             validAttributes = Object.assign({}, validAttributes, transformedAttribute);
-          } else if (attribute in ATTS_TRANSFORMED_NAMES) {
+          } 
+          else if (attribute in ATTS_TRANSFORMED_NAMES) {
             validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
-          } else if (attribute in ATTS_ENABLED) {
+          } 
+          else if (attribute in ATTS_ENABLED) {
             validAttributes[attribute] = attributeValue;
           }
       }

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ class SvgUri extends Component{
           const attributeValue = node.attributes[i].nodeValue;
           
           if (attribute in ATTS_TRANSFORM) {
-            const transformedAttribute = this.transformSVGAtt(node.nodeName, attribute, attributeValue);
+            const transformedAttribute = this.transformSVGAtt(attribute, attributeValue);
             validAttributes = Object.assign({}, validAttributes, transformedAttribute);
           } 
           else if (attribute in ATTS_TRANSFORMED_NAMES) {
@@ -148,7 +148,7 @@ class SvgUri extends Component{
       return validAttributes;
   }
 
-  transformSVGAtt(component, attName, attValue){
+  transformSVGAtt(attName, attValue){
       if (attName == 'style'){
           let styleAtts = attValue.split(';');
           let newAtts = {};

--- a/index.js
+++ b/index.js
@@ -128,20 +128,15 @@ class SvgUri extends Component{
 
   obtainComponentAtts(node, ATTS_ENABLED, ATTS_TRANSFORM){
       let componentAtts = {};
-      for (let i = 0; i < node.attributes.length; i++){
+      for (let i = 0; i < node.attributes.length; i++) {
           let att = node.attributes[i];
-          if (att.nodeName in ATTS_TRANSFORM){
-              att = this.transformSVGAtt(node.nodeName, att.nodeName, att.nodeValue);
-              componentAtts = Object.assign({}, componentAtts, att);
-          }else{
-
-              if (att.nodeName in ATTS_TRANSFORMED_NAMES){
-                componentAtts[ATTS_TRANSFORMED_NAMES[att.nodeName]] = att.nodeValue;
-              }else{
-                  if (att.nodeName in ATTS_ENABLED){ // Valida que el atributo sea mapeable
-                      componentAtts[att.nodeName] = att.nodeValue;
-                  }
-              }
+          if (att.nodeName in ATTS_TRANSFORM) {
+            att = this.transformSVGAtt(node.nodeName, att.nodeName, att.nodeValue);
+            componentAtts = Object.assign({}, componentAtts, att);
+          } else if (att.nodeName in ATTS_TRANSFORMED_NAMES) {
+            componentAtts[ATTS_TRANSFORMED_NAMES[att.nodeName]] = att.nodeValue;
+          } else if (att.nodeName in ATTS_ENABLED) {
+            componentAtts[att.nodeName] = att.nodeValue;
           }
       }
 

--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ class SvgUri extends Component{
 
   obtainComponentAtts(node, ATTS_ENABLED, ATTS_TRANSFORM) {
       let validAttributes = {};
+
       for (let i = 0; i < node.attributes.length; i++) {
           const attribute = node.attributes[i].nodeName;
           const attributeValue = node.attributes[i].nodeValue;
@@ -140,12 +141,13 @@ class SvgUri extends Component{
             validAttributes[ATTS_TRANSFORMED_NAMES[attribute]] = attributeValue;
           } 
           else if (attribute in ATTS_ENABLED) {
-            validAttributes[attribute] = attributeValue;
+            if (this.props.fill && attribute === 'fill') {
+                validAttributes[attribute] = this.props.fill;
+            }
+            else {
+                validAttributes[attribute] = attributeValue;
+            }
           }
-      }
-
-      if (this.props.fill && 'fill' in ATTS_ENABLED) {
-        return Object.assign({}, validAttributes, { fill: this.props.fill });
       }
 
       return validAttributes;

--- a/index.js
+++ b/index.js
@@ -121,7 +121,6 @@ class SvgUri extends Component{
             return <Stop key={i} {...componentAtts}>{childs}</Stop>;
         default:
           return null;
-          break;
         }
   }
 

--- a/index.js
+++ b/index.js
@@ -127,13 +127,13 @@ class SvgUri extends Component{
   obtainComponentAtts({attributes}, enabledAttributes, transformAttributes) {
       let validAttributes = {};
 
-      attributes.forEach(({nodeName, nodeValue}) => {
+      Array.from(attributes).forEach(({nodeName, nodeValue}) => {
           if (nodeName in transformAttributes) {
             Object.assign(validAttributes, this.transformSVGAtt(nodeName, nodeValue));
-          } 
+          }
           else if (nodeName in ATTS_TRANSFORMED_NAMES) {
             validAttributes[ATTS_TRANSFORMED_NAMES[nodeName]] = nodeValue;
-          } 
+          }
           else if (nodeName in enabledAttributes) {
             validAttributes[nodeName] = this.props.fill && nodeName === 'fill' ? this.props.fill : nodeValue;
           }


### PR DESCRIPTION
With this feature you can override svg's own fill attribute. This way you can give any color to svg file :) Fill prop is mainly targeted to one colored svgs like these: http://adamwhitcroft.com/climacons/

Example usage:

``` javascript
<SvgUri
  width="50"
  height="50"
  source={require('../images/Sun.svg')}
  fill="yellow"
/>
```

PS. If this gets merged next version should be 0.2.0 according to semantic versioning http://semver.org/#spec-item-7
