### PR TITLE
Allows update of svgXmlData after it renders

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ class SvgUri extends Component{
     this.obtainComponentAtts  = this.obtainComponentAtts.bind(this);
     this.inspectNode          = this.inspectNode.bind(this);
     this.fecthSVGData         = this.fecthSVGData.bind(this);
+    this.updateSVGData         = this.updateSVGData.bind(this);
 
     // Gets the image data from an URL or a static file
     if (props.source) {
@@ -86,6 +87,9 @@ class SvgUri extends Component{
      }
   }
 
+  updateSVGData(svgXmlData) {
+     this.setState({svgXmlData:svgXmlData});
+  }
 
   createSVGElement(node, childs){
         let componentAtts = {};


### PR DESCRIPTION
Add new function `updateSVGData` to enable update (re-render) of SVG XML Data should it changed after render.

This works for those that use Redux or Relay data source to retrieve SVG data not from external uri.