### PR TITLE
Update react-native-svg version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Matias Cortes",
   "license": "ISC",
   "dependencies": {
-    "react-native-svg": "^4.3.1",
+    "react-native-svg": "5.1.7",
     "xmldom": "^0.1.22"
   },
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "author": "Matias Cortes",
   "license": "ISC",
   "dependencies": {
-    "react-native-svg": "5.1.7",
     "xmldom": "^0.1.22"
+  },
+  "peerDependencies": {
+    "react-native-svg": "5.1.7"
   },
   "bugs": {
     "url": "https://github.com/matiascba/react-native-svg-uri/issues"


### PR DESCRIPTION
We are having a couple issues because it uses an old version of it, [here's the explanation](https://github.com/matc4/react-native-svg-uri/issues/33#issuecomment-302083295)