### PR TITLE
Remove empty strings from element children

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,6 @@ class SvgUri extends Component{
         for (let i = 0; i < node.childNodes.length; i++){
           const isTextValue = node.childNodes[i].nodeValue
           if (isTextValue) {
-            console.log(node)
             arrayElements.push(node.childNodes[i].nodeValue)
           } else {
             const nodo = this.inspectNode(node.childNodes[i]);

--- a/index.js
+++ b/index.js
@@ -139,8 +139,19 @@ class SvgUri extends Component{
 
     return responseXML;
   }
+   
+  // Remove empty strings from children array  
+  trimElementChilden(children) {
+    for (child of children) {
+      if (typeof child === 'string') {
+        if (child.trim.length === 0)
+          children.splice(children.indexOf(child), 1); 
+      }
+    }
+  }
 
   createSVGElement(node, childs){
+    this.trimElementChilden(childs);
     let componentAtts = {};
     const i = ind++;
     switch (node.nodeName) {


### PR DESCRIPTION
This fixes an issue which appeared with RN 0.46 and RNSVG 5.3.0, where SVG element children were surrounded by empty strings, causing SVG's not to be rendered and the hard to debug warning message `RawText " 
" must be wrapped in an explicit <Text> component`